### PR TITLE
:green_heart: Only run CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 name: Continuous Integration
 


### PR DESCRIPTION
CI was running on pushes to _any_ branch. Instead, only run CI on pushes to main.

Note: No changes when CI is run for pull requests. IOW, run CI for all pull requests.